### PR TITLE
adding electron and photon MVA V2 IDs

### DIFF
--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
@@ -283,6 +283,8 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     useTriggerObject          = cms.untracked.bool(False),
     edmEcalPFClusterIsoMapTag = cms.untracked.InputTag('electronEcalPFClusterIsolationProducer'),
     edmHcalPFClusterIsoMapTag = cms.untracked.InputTag('electronHcalPFClusterIsolationProducer'),
+    edmEleMVAV2Iso            = cms.untracked.string('ElectronMVAEstimatorRun2Fall17IsoV2'),
+    edmEleMVAV2NoIso          = cms.untracked.string('ElectronMVAEstimatorRun2Fall17NoIsoV2'),
     #----------------------    SETTINGS FOR 2017 (9X)     -----------------------
     edmEleMediumMVA           = cms.untracked.string('mvaEleID-Fall17-noIso-V1-wp90'),
     edmEleTightMVA            = cms.untracked.string('mvaEleID-Fall17-noIso-V1-wp80'),

--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
@@ -292,7 +292,9 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     edmEleMediumMVAIso        = cms.untracked.string('mvaEleID-Fall17-iso-V1-wp90'),
     edmEleTightMVAIso         = cms.untracked.string('mvaEleID-Fall17-iso-V1-wp80'),
     edmEleMVAIso              = cms.untracked.string('ElectronMVAEstimatorRun2Fall17IsoV1'),
+    edmEleMVAHZZ              = cms.untracked.string(''),
     storeSecondMVA            = cms.untracked.bool(True),
+    storeHZZMVA               = cms.untracked.bool(False),
   ),
   
   Muon = cms.untracked.PSet(

--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
@@ -313,6 +313,7 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     minPt                 = cms.untracked.double(10),
     edmName               = cms.untracked.string('slimmedPhotons'),
     edmSCName             = cms.untracked.InputTag('reducedEgamma','reducedSuperClusters'),
+    edmPhoMVAV2            = cms.untracked.string('PhotonMVAEstimatorRunIIFall17v2'),
     #FOR 2017 (8X)
     edmPhoMVA              = cms.untracked.string('PhotonMVAEstimatorRunIIFall17v1'),
     useTriggerObject      = cms.untracked.bool(False),

--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
@@ -278,6 +278,8 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     useTriggerObject          = cms.untracked.bool(False),
     edmEcalPFClusterIsoMapTag = cms.untracked.InputTag('electronEcalPFClusterIsolationProducer'),
     edmHcalPFClusterIsoMapTag = cms.untracked.InputTag('electronHcalPFClusterIsolationProducer'),
+    edmEleMVAV2Iso            = cms.untracked.string('ElectronMVAEstimatorRun2Fall17IsoV2'),
+    edmEleMVAV2NoIso          = cms.untracked.string('ElectronMVAEstimatorRun2Fall17NoIsoV2'),
     #----------------------    SETTINGS FOR 2016 (8X)     -----------------------
     edmEleMediumMVA           = cms.untracked.string('mvaEleID-Spring16-GeneralPurpose-V1-wp90'),
     edmEleTightMVA            = cms.untracked.string('mvaEleID-Spring16-GeneralPurpose-V1-wp80'),

--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
@@ -308,6 +308,7 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     minPt                 = cms.untracked.double(10),
     edmName               = cms.untracked.string('slimmedPhotons'),
     edmSCName             = cms.untracked.InputTag('reducedEgamma','reducedSuperClusters'),
+    edmPhoMVAV2            = cms.untracked.string('PhotonMVAEstimatorRunIIFall17v2'),
     #FOR 2016 (8X)
     edmPhoMVA              = cms.untracked.string('PhotonMVAEstimatorRun2Spring16NonTrigV1'),
     useTriggerObject      = cms.untracked.bool(False),

--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
@@ -287,7 +287,9 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     edmEleMediumMVAIso        = cms.untracked.string(''), 
     edmEleTightMVAIso         = cms.untracked.string(''),
     edmEleMVAIso              = cms.untracked.string(''),
+    edmEleMVAHZZ              = cms.untracked.string('ElectronMVAEstimatorRun2Spring16HZZV1'),
     storeSecondMVA            = cms.untracked.bool(False),
+    storeHZZMVA               = cms.untracked.bool(True),
   ),
   
   Muon = cms.untracked.PSet(

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
@@ -293,7 +293,9 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     edmEleMediumMVAIso        = cms.untracked.string('mvaEleID-Fall17-iso-V1-wp90'),
     edmEleTightMVAIso         = cms.untracked.string('mvaEleID-Fall17-iso-V1-wp80'),
     edmEleMVAIso              = cms.untracked.string('ElectronMVAEstimatorRun2Fall17IsoV1'),
+    edmEleMVAHZZ              = cms.untracked.string(''),
     storeSecondMVA            = cms.untracked.bool(True),
+    storeHZZMVA               = cms.untracked.bool(False),
   ),
   
   Muon = cms.untracked.PSet(

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
@@ -284,6 +284,8 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     useTriggerObject          = cms.untracked.bool(False),
     edmEcalPFClusterIsoMapTag = cms.untracked.InputTag('electronEcalPFClusterIsolationProducer'),
     edmHcalPFClusterIsoMapTag = cms.untracked.InputTag('electronHcalPFClusterIsolationProducer'),
+    edmEleMVAV2Iso            = cms.untracked.string('ElectronMVAEstimatorRun2Fall17IsoV2'),
+    edmEleMVAV2NoIso          = cms.untracked.string('ElectronMVAEstimatorRun2Fall17NoIsoV2'),
     #----------------------    SETTINGS FOR 2017 (9X)     -----------------------
     edmEleMediumMVA           = cms.untracked.string('mvaEleID-Fall17-noIso-V1-wp90'),
     edmEleTightMVA            = cms.untracked.string('mvaEleID-Fall17-noIso-V1-wp80'),

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
@@ -314,6 +314,7 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     minPt                 = cms.untracked.double(10),
     edmName               = cms.untracked.string('slimmedPhotons'),
     edmSCName             = cms.untracked.InputTag('reducedEgamma','reducedSuperClusters'),
+    edmPhoMVAV2            = cms.untracked.string('PhotonMVAEstimatorRunIIFall17v2'),
     #FOR 2017 (8X)
     edmPhoMVA              = cms.untracked.string('PhotonMVAEstimatorRunIIFall17v1'),
     useTriggerObject      = cms.untracked.bool(False),

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
@@ -294,7 +294,9 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     edmEleMediumMVAIso        = cms.untracked.string(''), 
     edmEleTightMVAIso         = cms.untracked.string(''),
     edmEleMVAIso              = cms.untracked.string(''),
+    edmEleMVAHZZ              = cms.untracked.string('ElectronMVAEstimatorRun2Spring16HZZV1'),
     storeSecondMVA            = cms.untracked.bool(False),
+    storeHZZMVA               = cms.untracked.bool(True),
   ),
   
   Muon = cms.untracked.PSet(

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
@@ -315,6 +315,7 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     minPt                 = cms.untracked.double(10),
     edmName               = cms.untracked.string('slimmedPhotons'),
     edmSCName             = cms.untracked.InputTag('reducedEgamma','reducedSuperClusters'),
+    edmPhoMVAV2            = cms.untracked.string('PhotonMVAEstimatorRunIIFall17v2'),
     #FOR 2016 (8X)
     edmPhoMVA              = cms.untracked.string('PhotonMVAEstimatorRun2Spring16NonTrigV1'),
     useTriggerObject      = cms.untracked.bool(False),

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
@@ -285,6 +285,8 @@ process.ntupler = cms.EDAnalyzer('NtuplerMod',
     useTriggerObject          = cms.untracked.bool(False),
     edmEcalPFClusterIsoMapTag = cms.untracked.InputTag('electronEcalPFClusterIsolationProducer'),
     edmHcalPFClusterIsoMapTag = cms.untracked.InputTag('electronHcalPFClusterIsolationProducer'),
+    edmEleMVAV2Iso            = cms.untracked.string('ElectronMVAEstimatorRun2Fall17IsoV2'),
+    edmEleMVAV2NoIso          = cms.untracked.string('ElectronMVAEstimatorRun2Fall17NoIsoV2'),
     #----------------------    SETTINGS FOR 2016 (8X)     -----------------------
     edmEleMediumMVA           = cms.untracked.string('mvaEleID-Spring16-GeneralPurpose-V1-wp90'),
     edmEleTightMVA            = cms.untracked.string('mvaEleID-Spring16-GeneralPurpose-V1-wp80'),

--- a/Ntupler/interface/FillerElectron.hh
+++ b/Ntupler/interface/FillerElectron.hh
@@ -97,7 +97,9 @@ namespace baconhep
       std::string fMediumMVAIso;
       std::string fTightMVAIso;
       std::string fMVAIso;
+      std::string fMVAHZZ;
       bool fSecondMVA;
+      bool fStoreHZZMVA;
       edm::InputTag fEleMediumIdIsoMapTag;
       edm::InputTag fEleTightIdIsoMapTag;
       edm::InputTag fMVAValuesIsoMapTag;

--- a/Ntupler/interface/FillerElectron.hh
+++ b/Ntupler/interface/FillerElectron.hh
@@ -82,13 +82,6 @@ namespace baconhep
       std::string fPuppiNoLepName; 
       bool fUsePuppi;
 
-      // PF cluster isolation info (not in AOD)
-      edm::InputTag fEcalPFClusterIsoMapTag;
-      edm::InputTag fHcalPFClusterIsoMapTag;
-      edm::InputTag fEleMediumIdMapTag;
-      edm::InputTag fEleTightIdMapTag;
-      edm::InputTag fMVAValuesMapTag;
-      edm::InputTag fMVACatsMapTag;
       std::string fMVAV2Iso;
       std::string fMVAV2NoIso;
       std::string fMediumMVA;
@@ -100,10 +93,6 @@ namespace baconhep
       std::string fMVAHZZ;
       bool fSecondMVA;
       bool fStoreHZZMVA;
-      edm::InputTag fEleMediumIdIsoMapTag;
-      edm::InputTag fEleTightIdIsoMapTag;
-      edm::InputTag fMVAValuesIsoMapTag;
-      edm::InputTag fMVACatsIsoMapTag;
       bool fUseTO;
       bool fUseAOD;
       
@@ -118,16 +107,6 @@ namespace baconhep
       edm::EDGetTokenT<reco::TrackCollection>        fTokTrackName;
       edm::EDGetTokenT<reco::ConversionCollection>   fTokConvName;
       edm::EDGetTokenT<reco::SuperClusterCollection> fTokSCName;
-      edm::EDGetTokenT<edm::ValueMap<float> > fTokEcalPFClusterIsoMap;
-      edm::EDGetTokenT<edm::ValueMap<float> > fTokHcalPFClusterIsoMap;
-      edm::EDGetTokenT<edm::ValueMap<bool> >  fTokEleMediumIdMap;
-      edm::EDGetTokenT<edm::ValueMap<bool> >  fTokEleTightIdMap;
-      edm::EDGetTokenT<edm::ValueMap<float> > fTokEleMVAValuesMap;
-      edm::EDGetTokenT<edm::ValueMap<int> >   fTokEleMVACatsMap;
-      edm::EDGetTokenT<edm::ValueMap<bool> >  fTokEleMediumIdIsoMap;
-      edm::EDGetTokenT<edm::ValueMap<bool> >  fTokEleTightIdIsoMap;
-      edm::EDGetTokenT<edm::ValueMap<float> > fTokEleMVAValuesIsoMap;
-      edm::EDGetTokenT<edm::ValueMap<int> >   fTokEleMVACatsIsoMap;
   };
 }
 #endif

--- a/Ntupler/interface/FillerElectron.hh
+++ b/Ntupler/interface/FillerElectron.hh
@@ -89,6 +89,8 @@ namespace baconhep
       edm::InputTag fEleTightIdMapTag;
       edm::InputTag fMVAValuesMapTag;
       edm::InputTag fMVACatsMapTag;
+      std::string fMVAV2Iso;
+      std::string fMVAV2NoIso;
       std::string fMediumMVA;
       std::string fTightMVA;
       std::string fMVA;

--- a/Ntupler/interface/FillerPhoton.hh
+++ b/Ntupler/interface/FillerPhoton.hh
@@ -89,6 +89,7 @@ namespace baconhep
       edm::InputTag fGammaIsoMapTag;
       edm::InputTag fPhoMVAMapTag;
       std::string fMVA;
+      std::string fMVAV2;
       bool fUseTO;
       bool fUseAOD;
  //      PhotonMVACalculator *fPhotonMVA; 

--- a/Ntupler/interface/FillerPhoton.hh
+++ b/Ntupler/interface/FillerPhoton.hh
@@ -78,16 +78,7 @@ namespace baconhep
       edm::EDGetTokenT<reco::GsfElectronCollection>  fTokEleName;
       edm::EDGetTokenT<reco::ConversionCollection>   fTokConvName;
       edm::EDGetTokenT<reco::SuperClusterCollection> fTokSCName;
-      edm::EDGetTokenT<edm::ValueMap<float> >        fTokChHadIsoMapTag;
-      edm::EDGetTokenT<edm::ValueMap<float> >        fTokNeuHadIsoMapTag;
-      edm::EDGetTokenT<edm::ValueMap<float> >        fTokGammaIsoMapTag;
-      edm::EDGetTokenT<edm::ValueMap<float> >        fTokPhoMVAMapTag;
       
-      // isolation info (EGM recommendation currently not in AOD/MINIAOD)
-      edm::InputTag fChHadIsoMapTag;
-      edm::InputTag fNeuHadIsoMapTag;
-      edm::InputTag fGammaIsoMapTag;
-      edm::InputTag fPhoMVAMapTag;
       std::string fMVA;
       std::string fMVAV2;
       bool fUseTO;

--- a/Ntupler/src/FillerElectron.cc
+++ b/Ntupler/src/FillerElectron.cc
@@ -38,7 +38,9 @@ FillerElectron::FillerElectron(const edm::ParameterSet &iConfig, const bool useA
   fMediumMVAIso          (iConfig.getUntrackedParameter<std::string>("edmEleMediumMVAIso")),
   fTightMVAIso           (iConfig.getUntrackedParameter<std::string>("edmEleTightMVAIso")),
   fMVAIso                (iConfig.getUntrackedParameter<std::string>("edmEleMVAIso")),
+  fMVAHZZ                (iConfig.getUntrackedParameter<std::string>("edmEleMVAHZZ")),
   fSecondMVA             (iConfig.getUntrackedParameter<bool>("storeSecondMVA",false)),
+  fStoreHZZMVA           (iConfig.getUntrackedParameter<bool>("storeHZZMVA",false)),
   fUseTO                 (iConfig.getUntrackedParameter<bool>("useTriggerObject",false)),
   fUseAOD                (useAOD)
 {
@@ -442,6 +444,11 @@ void FillerElectron::fill(TClonesArray *array,
       if (itEle->electronID(fTightMVAIso)) pElectron->mvaIsoBit |= baconhep::kEleMVATightBit;
       pElectron->mvaIso = itEle->userFloat(fMVAIso+"Values");
       pElectron->mvaIsoCat = itEle->userInt(fMVAIso+"Categories");
+    }
+
+    if (fStoreHZZMVA) {
+        pElectron->mvaHZZ = itEle->userFloat(fMVAHZZ+"Values");
+        pElectron->mvaHZZCat = itEle->userInt(fMVAHZZ+"Categories");
     }
 
     pElectron->isConv     = !itEle->passConversionVeto();

--- a/Ntupler/src/FillerElectron.cc
+++ b/Ntupler/src/FillerElectron.cc
@@ -30,6 +30,8 @@ FillerElectron::FillerElectron(const edm::ParameterSet &iConfig, const bool useA
   fPuppiName             (iConfig.getUntrackedParameter<std::string>("edmPuppiName","puppi")),
   fPuppiNoLepName        (iConfig.getUntrackedParameter<std::string>("edmPuppiNoLepName","puppiNoLep")),
   fUsePuppi              (iConfig.getUntrackedParameter<bool>("usePuppi",true)),
+  fMVAV2Iso              (iConfig.getUntrackedParameter<std::string>("edmEleMVAV2Iso")),
+  fMVAV2NoIso            (iConfig.getUntrackedParameter<std::string>("edmEleMVAV2NoIso")),
   fMediumMVA             (iConfig.getUntrackedParameter<std::string>("edmEleMediumMVA")),
   fTightMVA              (iConfig.getUntrackedParameter<std::string>("edmEleTightMVA")),
   fMVA                   (iConfig.getUntrackedParameter<std::string>("edmEleMVA")),
@@ -421,6 +423,12 @@ void FillerElectron::fill(TClonesArray *array,
     pElectron->dEtaInSeed = dEtaInSeed(*itEle);
     pElectron->dEtaIn     = itEle->deltaEtaSuperClusterTrackAtVtx();
     pElectron->dPhiIn     = itEle->deltaPhiSuperClusterTrackAtVtx();
+
+    // saving v2 electron MVA IDs
+    pElectron->mvaV2Iso     = itEle->userFloat(fMVAV2Iso+"Values");
+    pElectron->mvaV2NoIso   = itEle->userFloat(fMVAV2NoIso+"Values");
+    pElectron->mvaV2IsoCat     = itEle->userInt(fMVAV2Iso+"Categories");
+    pElectron->mvaV2NoIsoCat   = itEle->userInt(fMVAV2NoIso+"Categories");
 
     pElectron->mvaBit     = 0; 
     if (itEle->electronID(fMediumMVA)) pElectron->mvaBit |= baconhep::kEleMVAMedBit;

--- a/Ntupler/src/FillerPhoton.cc
+++ b/Ntupler/src/FillerPhoton.cc
@@ -32,6 +32,7 @@ FillerPhoton::FillerPhoton(const edm::ParameterSet &iConfig, const bool useAOD,e
   fConvName          (iConfig.getUntrackedParameter<std::string>("edmConversionName","allConversions")),
   fSCName            (iConfig.getUntrackedParameter<edm::InputTag>("edmSCName")),//,"particleFlowEGamma")),
   fMVA               (iConfig.getUntrackedParameter<std::string>("edmPhoMVA")),
+  fMVAV2             (iConfig.getUntrackedParameter<std::string>("edmPhoMVAV2")),
   fUseTO             (iConfig.getUntrackedParameter<bool>("useTriggerObject",false)),
   fUseAOD            (useAOD)
 {
@@ -310,7 +311,11 @@ void FillerPhoton::fill(TClonesArray *array,
 
     // Photon MVA ID: https://twiki.cern.ch/twiki/bin/view/CMS/MultivariatePhotonIdentificationRun2
     pPhoton->mva = itPho->userFloat(fMVA+"Values"); 
-
+    pPhoton->mvaCat = itPho->userInt(fMVA+"Categories"); 
+    
+    // v2 photon MVA
+    pPhoton->mvaV2 = itPho->userFloat(fMVAV2+"Values");
+    pPhoton->mvaV2Cat = itPho->userInt(fMVAV2+"Categories");
 
     if(fUseTO) pPhoton->hltMatchBits = TriggerTools::matchHLT(pPhoton->eta, pPhoton->phi, triggerRecords, triggerObjects);
   }


### PR DESCRIPTION
This adds the Fall17V2 electron and photon MVA IDs to Bacon. These are expected to perform better than v1 in general, and it's recommended to use them for 2016 for consistency. So I am proposing they are saved for all years. The old MVA values are still stored for 2016, so Bacon users can choose to stick with the old IDs if they so choose.

The HZZ MVA electron ID is also added for 2016 with a configuration flag to toggle on/off. 