### PR TITLE
adding l1 prefiring weights and uncertainties

### DIFF
--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD.py
@@ -134,6 +134,12 @@ setupEgammaPostRecoSeq(process,
                        era='2017-Nov17ReReco', #era is new to select between 2016 / 2017,  it defaults to 2017
                        phoIDModules=[]) #bug with default modules for photon VID; off for now
 
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2017BtoF"), 
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
 # PF MET corrections
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 runMetCorAndUncFromMiniAOD(process,
@@ -753,6 +759,7 @@ process.baconSequence = cms.Sequence(
                                      process.ak4PuppiL1FastL2L3Corrector*
                                      process.pfNoPileUpJME            *
                                      process.egammaPostRecoSeq        *
+                                     process.prefiringweight          *
                                      process.puppiMETSequence          *
                                      #process.genjetsequence           *
                                      #process.AK4genjetsequenceCHS     *

--- a/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_Data_25ns_MINIAOD_8X.py
@@ -130,6 +130,12 @@ setupEgammaPostRecoSeq(process,
                        era='2016-Legacy', #era is new to select between 2016 / 2017,  it defaults to 2017
                        phoIDModules=[]) #bug with default modules for photon VID; off for now
 
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2016BtoH"), 
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
 # PF MET corrections
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 runMetCorAndUncFromMiniAOD(process,
@@ -747,6 +753,7 @@ process.baconSequence = cms.Sequence(
                                      process.ak4PuppiL1FastL2L3Corrector*
                                      process.pfNoPileUpJME            *
                                      process.egammaPostRecoSeq        *
+                                     process.prefiringweight          *
                                      process.puppiMETSequence          *
                                      #process.genjetsequence           *
                                      #process.AK4genjetsequenceCHS     *

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD.py
@@ -132,6 +132,14 @@ setupEgammaPostRecoSeq(process,
                        era='2017-Nov17ReReco', #era is new to select between 2016 / 2017,  it defaults to 2017
                        phoIDModules=[]) #bug with default modules for photon VID; off for now
 
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2017BtoF"), 
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
+
+
 # PF MET corrections
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 runMetCorAndUncFromMiniAOD(process,
@@ -756,6 +764,7 @@ process.baconSequence = cms.Sequence(
                                      process.ak8PuppiL1FastL2L3Chain  *
                                      process.pfNoPileUpJME            *
                                      process.egammaPostRecoSeq        *
+                                     process.prefiringweight          *
                                      process.puppiMETSequence          *
                                      process.genjetsequence            *
                                      process.AK4genjetsequenceCHS      *

--- a/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
+++ b/Ntupler/config/makingBacon_MC_25ns_MINIAOD_8X.py
@@ -132,6 +132,12 @@ setupEgammaPostRecoSeq(process,
                        era='2016-Legacy', #era is new to select between 2016 / 2017,  it defaults to 2017
                        phoIDModules=[]) #bug with default modules for photon VID; off for now
 
+from PhysicsTools.PatUtils.l1ECALPrefiringWeightProducer_cfi import l1ECALPrefiringWeightProducer
+process.prefiringweight = l1ECALPrefiringWeightProducer.clone(
+    DataEra = cms.string("2016BtoH"), 
+    UseJetEMPt = cms.bool(False),
+    PrefiringRateSystematicUncty = cms.double(0.2),
+    SkipWarnings = False)
 # PF MET corrections
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 runMetCorAndUncFromMiniAOD(process,
@@ -752,6 +758,7 @@ process.baconSequence = cms.Sequence(
                                      process.ak8PuppiL1FastL2L3Chain  *
                                      process.pfNoPileUpJME            *
                                      process.egammaPostRecoSeq        *
+                                     process.prefiringweight          *
                                      process.puppiMETSequence         *
                                      process.genjetsequence           *
                                      process.AK4genjetsequenceCHS     *

--- a/Ntupler/interface/FillerEventInfo.hh
+++ b/Ntupler/interface/FillerEventInfo.hh
@@ -102,6 +102,9 @@ namespace baconhep
     edm::EDGetTokenT<bool>                        fTokBadChCand                    ;
     edm::EDGetTokenT<bool>                        fTokBadPFMuon                    ;
     edm::EDGetTokenT<edm::TriggerResults>         fTokMetFiltersTag                ;
+    edm::EDGetTokenT<double>                      fTokPrefWeight                    ;
+    edm::EDGetTokenT<double>                      fTokPrefWeightUp                  ;
+    edm::EDGetTokenT<double>                      fTokPrefWeightDown                ;
   };
 }
 #endif

--- a/Ntupler/src/FillerEventInfo.cc
+++ b/Ntupler/src/FillerEventInfo.cc
@@ -59,6 +59,9 @@ FillerEventInfo::FillerEventInfo(const edm::ParameterSet &iConfig, const bool us
   edm::InputTag lBadChCand      ("BadChargedCandidateFilter");
   edm::InputTag lBadPFMuon      ("BadPFMuonFilter");
   edm::InputTag lMetFilters     ("TriggerResults","");
+  edm::InputTag lPrefiring      ("prefiringweight:nonPrefiringProb");
+  edm::InputTag lPrefiringUp    ("prefiringweight:nonPrefiringProbUp");
+  edm::InputTag lPrefiringDown  ("prefiringweight:nonPrefiringProbDown");
   fTokBeamHaloSummary                    = iC.consumes<reco::BeamHaloSummary> (lBeamHaloSummary);
   fTokHBHENoiseFilterResultProducer      = iC.consumes<bool>                  (lHBHENoiseFilter);
   fTokHcalLaserEventFilter               = iC.consumes<bool>                  (lLaserEvtFilter);
@@ -71,6 +74,9 @@ FillerEventInfo::FillerEventInfo(const edm::ParameterSet &iConfig, const bool us
   fTokBadChCand                          = iC.consumes<bool>                  (lBadChCand);
   fTokBadPFMuon                          = iC.consumes<bool>                  (lBadPFMuon);
   fTokMetFiltersTag                      = iC.consumes<edm::TriggerResults>   (lMetFilters);
+  fTokPrefWeight                         = iC.consumes<double>                (lPrefiring);
+  fTokPrefWeightUp                       = iC.consumes<double>                (lPrefiringUp);
+  fTokPrefWeightDown                     = iC.consumes<double>                (lPrefiringDown);
 }
 //--------------------------------------------------------------------------------------------------
 FillerEventInfo::~FillerEventInfo(){}
@@ -128,6 +134,19 @@ void FillerEventInfo::fill(TEventInfo *evtInfo,
   evtInfo->bsx = bs->x0();
   evtInfo->bsy = bs->y0();
   evtInfo->bsz = bs->z0();
+
+  // Egamma prefiring weights
+  edm::Handle<double> prefweight;
+  iEvent.getByToken(fTokPrefWeight, prefweight);
+  evtInfo->prefweight = (*prefweight);
+
+  edm::Handle<double> prefweightUp;
+  iEvent.getByToken(fTokPrefWeightUp, prefweightUp);
+  evtInfo->prefweightUp = (*prefweightUp);
+  
+  edm::Handle<double> prefweightDown;
+  iEvent.getByToken(fTokPrefWeightDown, prefweightDown);
+  evtInfo->prefweightDown = (*prefweightDown);
   	
 
   //


### PR DESCRIPTION
This adds the Egamma L1 prefiring recipe for 2016 and 2017. The procedure is described here:

https://twiki.cern.ch/twiki/bin/viewauth/CMS/L1ECALPrefiringWeightRecipe

Weights and uncertainties are calculated and stored in FillerEventInfo. This implementation would store the weights for all data and MC for all eras, but it's worth noting that the weights are meant to be applied to 2016 and 2017 MC only. 