### PR TITLE
avoid trigger memory bug

### DIFF
--- a/Ntupler/plugins/NtuplerMod.cc
+++ b/Ntupler/plugins/NtuplerMod.cc
@@ -714,6 +714,7 @@ void NtuplerMod::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 //--------------------------------------------------------------------------------------------------
 void NtuplerMod::initHLT(const edm::TriggerResults& result, const edm::TriggerNames& triggerNames)
 {
+  assert(kNTrigBit >= fTrigger->fRecords.size()); // check that TriggerBits is sufficiently long 
   for(unsigned int irec=0; irec<fTrigger->fRecords.size(); irec++) {
     fTrigger->fRecords[irec].hltPathName  = "";
     fTrigger->fRecords[irec].hltPathIndex = (unsigned int)-1;


### PR DESCRIPTION
Adding triggers to Bacon (HLT file) can potentially lead to a memory issue and crash if the number of trigger paths exceeds the size of TriggerBits, set by kNTrigBit in BaconAnaDefs.hh. 

This adds an assert statement in NtuplerMod.cc to terminate execution if TriggerBits is not sufficiently large. 